### PR TITLE
Updated `index.html` with the proper language.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html lang="de"><head><meta charset="utf-8"></head><body><div id="app"></div><script src="index_bundle.js"></script></body></html>
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"></head><body><div id="app"></div><script src="index_bundle.js"></script></body></html>


### PR DESCRIPTION
Setting `en` is the default behavior.

Without this setting everyone (except germans) will receive this kind of warning:
<img width="1280" alt="2016-10-28 12 33 20" src="https://cloud.githubusercontent.com/assets/4660275/19802106/bfec7684-9d0a-11e6-934e-17b1b6110651.png">
